### PR TITLE
fix: URLSearchParams fallback

### DIFF
--- a/client.js
+++ b/client.js
@@ -15,8 +15,16 @@ var options = {
   ansiColors: {},
 };
 if (__resourceQuery) {
-  var { URLSearchParams } = require('url');
-  var overrides = new URLSearchParams(__resourceQuery.slice(1));
+  var overrides;
+  if (
+    typeof window !== undefined &&
+    typeof window.URLSearchParams !== undefined
+  ) {
+    overrides = new URLSearchParams(__resourceQuery.slice(1));
+  } else {
+    const { URLSearchParams } = require('url');
+    overrides = new URLSearchParams(__resourceQuery.slice(1));
+  }
   setOverrides(Object.fromEntries(overrides));
 }
 


### PR DESCRIPTION

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

My project has the `url` package installed https://www.npmjs.com/package/url, which doesn't have support for `URLSearchParams` yet. 
So `new URLSearchParams` here throws.

I couldn't find any way on my end to make it resolve to the node `url`, so I've added this change to try to use `window.URLSearchParams` first. 

An alternative would be installing and requiring https://github.com/ungap/url-search-params here instead.

### Breaking Changes

### Additional Info
